### PR TITLE
Remove 3.5 support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Installation
 
    $ pip install aiosignal
 
-The library requires Python 3.5.3 or newer.
+The library requires Python 3.6 or newer.
 
 
 Documentation
@@ -73,8 +73,8 @@ Feel free to post your questions and ideas here.
 Requirements
 ============
 
-- Python >= 3.5.3
-- frozenlist >= 1.0.0a0
+- Python >= 3.6
+- frozenlist >= 1.0.0
 
 License
 =======

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@
 import io
 import os
 import re
-import sys
+
 
 _docs_path = os.path.dirname(__file__)
 _version_path = os.path.abspath(os.path.join(_docs_path,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,7 +47,7 @@ Installation
 
    $ pip install aiosignal
 
-The library requires Python 3.5.3 or newer.
+The library requires Python 3.6 or newer.
 
 Dependencies
 ------------
@@ -71,7 +71,8 @@ Feel free to post your questions and ideas here.
 Requirements
 ============
 
-- Python >= 3.5.3
+- Python >= 3.6
+- frozenlist >= 1.0.0
 
 License
 =======

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ import sys
 
 from setuptools import setup
 
-if sys.version_info < (3, 5, 3):
-    raise RuntimeError("aiosignal 1.x requires Python 3.5.3+")
+if sys.version_info < (3, 6):
+    raise RuntimeError("aiosignal 1.x requires Python 3.6+")
 
 
 here = pathlib.Path(__file__).parent
@@ -19,7 +19,7 @@ except IndexError:
     raise RuntimeError('Unable to determine version.')
 
 install_requires = [
-    'frozenlist>=1.0.0a0',
+    'frozenlist>=1.0.0',
 ]
 
 
@@ -38,7 +38,6 @@ args = dict(
         'Intended Audience :: Developers',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Development Status :: 5 - Production/Stable',
@@ -63,7 +62,7 @@ args = dict(
     },
     license='Apache 2',
     packages=['aiosignal'],
-    python_requires='>=3.5.3',
+    python_requires='>=3.6',
     install_requires=install_requires,
     include_package_data=True,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 
-envlist = check, clean, {py35,py36,py37}-{debug,release}, report
+envlist = check, clean, {py36,py37,py38}-{debug,release}, report
 
 [testenv]
 
@@ -20,9 +20,9 @@ setenv =
     debug: PYTHONASYNCIODEBUG = 1
 
 basepython:
-    py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 
 [testenv:check]
 
@@ -37,7 +37,7 @@ commands =
     python setup.py check -rms
 
 basepython:
-    python3.6
+    python3.7
 
 [testenv:clean]
 
@@ -48,7 +48,7 @@ commands =
     coverage erase
 
 basepython:
-    python3.6
+    python3.7
 
 [testenv:report]
 
@@ -64,4 +64,4 @@ whitelist_externals =
     echo
 
 basepython:
-    python3.6
+    python3.7


### PR DESCRIPTION
Aiohttp dropped support for 4.0+, and so did frozenlist 1.0.0.
