### PR TITLE
Bump pytest and pytest-asyncio deps

### DIFF
--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -1,10 +1,9 @@
 -r flake.txt
+-r ci-wheel.txt
+
 coverage==5.1
-pytest==5.3.5
-pytest-asyncio==0.10.0
 pytest-cov==2.8.1
 tox==3.14.6
-twine==3.1.1
 
 # Using PEP 508 env markers to control dependency on runtimes:
 codecov==2.0.22

--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -1,5 +1,5 @@
 -r flake.txt
--r ci-wheel.txt
+-r wheel.txt
 
 coverage==5.1
 pytest-cov==2.8.1

--- a/requirements/wheel.txt
+++ b/requirements/wheel.txt
@@ -1,3 +1,3 @@
-pytest==5.3.5
-pytest-asyncio==0.10.0
+pytest==5.4.1
+pytest-asyncio==0.11.0
 twine==3.1.1


### PR DESCRIPTION
Bumping these together as one requires the other.

Should make #58 and #70 obsolete.