### PR TITLE
Explicitly set junit_family to silence pytest warnings

### DIFF
--- a/pytest.ci.ini
+++ b/pytest.ci.ini
@@ -2,6 +2,7 @@
 addopts = --cov=aiosignal --cov-report term-missing:skip-covered -v -rxXs
 filterwarnings = error
 junit_suite_name = aiosignal_test_suite
+junit_family = xunit2
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2
 testpaths = tests/

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 addopts = --cov=aiosignal -v -rxXs
 filterwarnings = error
 junit_suite_name = aiosignal_test_suite
+junit_family = xunit2
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2
 testpaths = tests/


### PR DESCRIPTION
This should get rid of the pesky `##[warning]The 'junit_family' default value will change to 'xunit2' in pytest 6.0.` entries on Azure.