### PR TITLE
Mark aiosignal as Python3-only package

### DIFF
--- a/CHANGES/165.bugfix
+++ b/CHANGES/165.bugfix
@@ -1,0 +1,1 @@
+Mark aiosignal as Python3-only package

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,9 +7,6 @@ license_file = LICENSE.txt
 [pep8]
 max-line-length=79
 
-[bdist_wheel]
-universal = 1
-
 [easy_install]
 zip_ok = false
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ args = dict(
         'Intended Audience :: Developers',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
The generated wheel was declared as *universal* by mistake.