### PR TITLE
CI: leave running pre-commit to pre-commit.ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,7 @@ all: test
 
 lint:
 # CI env-var is set by GitHub actions
-ifdef CI
-	pre-commit run --all-files --show-diff-on-failure
-else
+ifndef CI
 	pre-commit run --all-files
 endif
 	mypy aiosignal


### PR DESCRIPTION
pre-commit.ci runs the pre-commit command way, way faster, this'll save 3-4
minutes during linting.
