### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/CHANGES/362.misc
+++ b/CHANGES/362.misc
@@ -1,0 +1,1 @@
+Removed unnecessary explicit requirement of `wheel` package from `pyproject.toml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
   "setuptools>=51.0",
-  "wheel>=0.36",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
## What do these changes do?

Remove the redundant `wheel` dependency, as it is added by the backend automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since, see: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a

## Are there changes in behavior for the user?

nope.

## Related issue number

n/a

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
