### PR TITLE
Update check-jsonschema URL and version to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,8 +64,8 @@ repos:
     - 'SC2086:'
     - -ignore
     - 'SC1004:'
-- repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.9.1
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.19.2
   hooks:
   - id: check-github-actions
 ci:


### PR DESCRIPTION
Hi there! I've introduced myself to aio-libs on a couple of other issues (see: https://github.com/aio-libs/pytest-aiohttp/pull/48 , https://github.com/aio-libs/frozenlist/pull/361).

For now, this is the last one I'm going to open. If I see more aio-libs in my searches for configs to update, I'll skip them to avoid spamming the project.

As in the other cases, I suspect that the `ci.skip` config can be removed, but am refraining from including that in my proposed changes for now.