### PR TITLE
ci: Switch to new libenchant-2-dev package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         make lint
     - name: Install spell checker
       run: |
-        sudo apt install libenchant-dev
+        sudo apt install libenchant-2-dev
         pip install -r requirements/doc-spelling.txt
         pip install -r requirements/towncrier.txt
     - name: Run docs spelling


### PR DESCRIPTION
The GH runners have been upgraded to Ubuntu 22.04, where libenchant-dev is no
longer available.

