### PR TITLE
ci: Update the flake8 pre-commit hook URL.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
   - id: check-xml
   - id: check-yaml
   - id: debug-statements
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
   - id: flake8


### PR DESCRIPTION
Flake8 moved away from gitlab and now the URL breaks.
