### PR TITLE
ci: Update RTD config to build with newer Python

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,8 +2,10 @@ version: 2
 
 build:
   image: latest
+  tools:
+    os: ubuntu-22.04
+    python: 3.10
 
 python:
-  version: 3.7
   install:
   - requirements: requirements/doc.txt


### PR DESCRIPTION
Use the newer build.tools.python setting to set the version. We need at least
3.8 for Sphinx 6.x to build on.
