### PR TITLE
Drop sphinxcontrib-asyncio doc dependency

### DIFF
--- a/CHANGES/528.doc
+++ b/CHANGES/528.doc
@@ -1,0 +1,1 @@
+Removed the sphinxcontrib-asyncio documentation dependency.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,6 @@ with open(_version_path, encoding="latin1") as fp:
 extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
-    "sphinxcontrib.asyncio",
 ]
 
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,4 +1,3 @@
 sphinx==7.1.2
-sphinxcontrib-asyncio==0.3.0
 pygments>=2.1
 aiohttp-theme==0.1.6


### PR DESCRIPTION
It is not compatible with current versions of Sphinx (https://github.com/aio-libs/sphinxcontrib-asyncio/issues/15), and none of the extra syntax documented in https://sphinxcontrib-asyncio.readthedocs.io/en/latest/ appears to be used anyway.

<!-- Thank you for your contribution! -->

## What do these changes do?

Remove the [`sphinxcontrib-asyncio`](https://github.com/aio-libs/sphinxcontrib-asyncio/) extension from the Sphinx configuration in `docs/conf.py` and from the requirements file `requirements/doc.txt`

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No, the documentation still builds without warnings and looks normal.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist **N/A, nothing to test**
- [ ] Documentation reflects the changes **N/A, there doesn’t seem to be anything to document**
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` **N/A, a trivial non-code contribution**
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
