### PR TITLE
🧪 Add a dedicated CI/CD job for building the dists

### DIFF
--- a/.github/actions/cache-keys/action.yml
+++ b/.github/actions/cache-keys/action.yml
@@ -1,0 +1,41 @@
+outputs:
+  cache-key-for-dep-files:
+    description: >-
+      A cache key string derived from the dependency declaration files.
+    value: ${{ steps.calc-cache-key-files.outputs.files-hash-key }}
+
+runs:
+  using: composite
+  steps:
+  - name: >-
+      Calculate dependency files' combined hash value
+      for use in the cache key
+    id: calc-cache-key-files
+    run: |
+      from os import environ
+      from pathlib import Path
+
+      FILE_APPEND_MODE = 'a'
+
+      files_derived_hash = '${{
+          hashFiles(
+            'tox.ini',
+            'pyproject.toml',
+            '.pre-commit-config.yaml',
+            'pytest.ini',
+            'requirements/**',
+            'setup.cfg',
+            'setup.py'
+          )
+      }}'
+
+      print(f'Computed file-derived hash is {files_derived_hash}.')
+
+      with Path(environ['GITHUB_OUTPUT']).open(
+              mode=FILE_APPEND_MODE,
+      ) as outputs_file:
+          print(
+              f'files-hash-key={files_derived_hash}',
+              file=outputs_file,
+          )
+    shell: python

--- a/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-tox-run/action.yml
+++ b/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-tox-run/action.yml
@@ -1,0 +1,71 @@
+inputs:
+  calling-job-context:
+    description: A JSON with the calling job inputs
+    type: string
+  job-dependencies-context:
+    default: >-
+      {}
+    description: >-
+      The `$ {{ needs }}` context passed from the calling workflow
+      encoded as a JSON string. The caller is expected to form this
+      input as follows:
+      `job-dependencies-context: $ {{ toJSON(needs) }}`.
+    required: false
+    type: string
+
+runs:
+  using: composite
+  steps:
+  - name: Verify that the artifacts with expected names got created
+    if: fromJSON(inputs.calling-job-context).toxenv == 'build-dists'
+    run: >
+      # Verify that the artifacts with expected names got created
+
+
+      ls -1
+      dist/${{
+        fromJSON(
+          inputs.job-dependencies-context
+        ).pre-setup.outputs.sdist-artifact-name
+      }}
+      dist/${{
+        fromJSON(
+          inputs.job-dependencies-context
+        ).pre-setup.outputs.wheel-artifact-name
+      }}
+    shell: bash
+  - name: Store the distribution packages
+    if: fromJSON(inputs.calling-job-context).toxenv == 'build-dists'
+    uses: actions/upload-artifact@v4
+    with:
+      name: >-
+        ${{
+          fromJSON(
+            inputs.job-dependencies-context
+          ).pre-setup.outputs.dists-artifact-name
+        }}
+      # NOTE: Exact expected file names are specified here
+      # NOTE: as a safety measure — if anything weird ends
+      # NOTE: up being in this dir or not all dists will be
+      # NOTE: produced, this will fail the workflow.
+      path: |
+        dist/${{
+          fromJSON(
+            inputs.job-dependencies-context
+          ).pre-setup.outputs.sdist-artifact-name
+        }}
+        dist/${{
+          fromJSON(
+            inputs.job-dependencies-context
+          ).pre-setup.outputs.wheel-artifact-name
+        }}
+      retention-days: >-
+        ${{
+            fromJSON(
+              fromJSON(
+                inputs.job-dependencies-context
+              ).pre-setup.outputs.release-requested
+            )
+            && 90
+            || 30
+        }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,11 +32,117 @@ env:
   PY_COLORS: 1  # Recognized by the `py` package, dependency of `pytest`
   PYTHONIOENCODING: utf-8
   PYTHONUTF8: 1
+  TOX_PARALLEL_NO_SPINNER: 1  # Disable tox's parallel run spinner animation
+  TOX_TESTENV_PASSENV: >-  # Make tox-wrapped tools see color requests
+    FORCE_COLOR
+    MYPY_FORCE_COLOR
+    NO_COLOR
+    PIP_DISABLE_PIP_VERSION_CHECK
+    PIP_NO_PYTHON_VERSION_WARNING
+    PIP_NO_WARN_SCRIPT_LOCATION
+    PRE_COMMIT_COLOR
+    PY_COLORS
+    PYTEST_THEME
+    PYTEST_THEME_MODE
+    PYTHONIOENCODING
+    PYTHONLEGACYWINDOWSSTDIO
+    PYTHONUTF8
+  UPSTREAM_REPOSITORY_ID: >-
+    205007356
 
 
 jobs:
+  pre-setup:
+    name: ⚙️ Pre-set global build settings
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 2  # network is slow sometimes when fetching from Git
+
+    defaults:
+      run:
+        shell: python
+
+    outputs:
+      # NOTE: These aren't env vars because the `${{ env }}` context is
+      # NOTE: inaccessible when passing inputs to reusable workflows.
+      dists-artifact-name: python-package-distributions
+      release-requested: >-
+        ${{
+          (
+            github.event_name == 'push'
+            && github.ref_type == 'tag'
+          )
+          && true
+          || false
+        }}
+      cache-key-for-dep-files: >-
+        ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
+      sdist-artifact-name: ${{ steps.artifact-name.outputs.sdist }}
+      wheel-artifact-name: ${{ steps.artifact-name.outputs.wheel }}
+      upstream-repository-id: ${{ env.UPSTREAM_REPOSITORY_ID }}
+
+    steps:
+    - name: Switch to using Python 3.11 by default
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+    - name: Check out src from Git
+      uses: actions/checkout@v4
+    - name: >-
+        Calculate dependency files' combined hash value
+        for use in the cache key
+      id: calc-cache-key-files
+      uses: ./.github/actions/cache-keys
+    - name: Set the expected dist artifact names
+      id: artifact-name
+      run: |
+        from os import environ
+        from pathlib import Path
+
+        FILE_APPEND_MODE = 'a'
+
+        whl_file_prj_base_name = '${{ env.PROJECT_NAME }}'.replace('-', '_')
+        sdist_file_prj_base_name = whl_file_prj_base_name.replace('.', '_')
+
+        with Path(environ['GITHUB_OUTPUT']).open(
+                mode=FILE_APPEND_MODE,
+        ) as outputs_file:
+            print(
+                f"sdist={sdist_file_prj_base_name !s}-*.tar.gz",
+                file=outputs_file,
+            )
+            print(
+                f"wheel={whl_file_prj_base_name !s}-*-py2.py3-none-any.whl",
+                file=outputs_file,
+            )
+
+  build:
+    name: >-
+      📦 ${{ github.ref_name }}
+    needs:
+    - pre-setup
+
+
+    uses: tox-dev/workflow/.github/workflows/reusable-tox.yml@89de3c6be3cd179adf71e28aa4ac5bef60804209  # yamllint disable-line rule:line-length
+    with:
+      cache-key-for-dependency-files: >-
+        ${{ needs.pre-setup.outputs.cache-key-for-dep-files }}
+      check-name: Build dists under 🐍3.13
+      job-dependencies-context: >-  # context for hooks
+        ${{ toJSON(needs) }}
+      python-version: 3.13
+      runner-vm-os: ubuntu-latest
+      timeout-minutes: 2
+      toxenv: build-dists
+      xfail: false
+
   lint:
     name: Linter
+    needs:
+    - build
+    - pre-setup  # transitive, for accessing settings
+
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -53,9 +159,15 @@ jobs:
       uses: py-actions/py-dependency-install@v4
       with:
         path: requirements/dev.txt
-    - name: Install itself
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: >-
+          ${{ needs.pre-setup.outputs.dists-artifact-name }}
+        path: dist/
+    - name: Install ${{ env.PROJECT_NAME }} from the pre-built wheel
       run: |
-        pip install .
+        pip install dist/${{ needs.pre-setup.outputs.wheel-artifact-name }}
     - name: Run linter
       run: |
         make lint
@@ -70,8 +182,7 @@ jobs:
         make doc-spelling
     - name: Prepare twine checker
       run: |
-        pip install -U twine build
-        python -m build
+        pip install -U twine
     - name: Run twine checker
       run: |
         twine check --strict dist/*
@@ -81,6 +192,10 @@ jobs:
 
   test:
     name: Test
+    needs:
+    - build
+    - pre-setup  # transitive, for accessing settings
+
     strategy:
       matrix:
         pyver: ['3.9', '3.10', '3.11', '3.12', '3.13']
@@ -100,7 +215,16 @@ jobs:
     - name: Install dependencies
       uses: py-actions/py-dependency-install@v4
       with:
-        path: requirements/ci-bot.txt
+        path: requirements/ci-wheel.txt
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: >-
+          ${{ needs.pre-setup.outputs.dists-artifact-name }}
+        path: dist/
+    - name: Install ${{ env.PROJECT_NAME }} from the pre-built wheel
+      run: |
+        pip install dist/${{ needs.pre-setup.outputs.wheel-artifact-name }}
     - name: Run unittests
       run: |
         python -m pytest tests -vv
@@ -127,9 +251,15 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    needs: test-summary
+    needs:
+    - pre-setup  # transitive, for accessing settings
+    - test-summary
     # Run only on pushing a tag
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    if: >-
+      always()
+      && needs.test-summary.result == 'success'
+      && fromJSON(needs.pre-setup.outputs.release-requested)
+      && needs.pre-setup.outputs.upstream-repository-id == github.repository_id
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
       id-token: write  # IMPORTANT: mandatory for trusted publishing & sigstore
@@ -137,16 +267,12 @@ jobs:
       name: pypi
       url: https://pypi.org/p/${{ env.PROJECT_NAME }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Setup Python
-      uses: actions/setup-python@v5
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
       with:
-        python-version: 3.13
-    - name: Install dependencies
-      run: python -m pip install -U pip wheel build
-    - name: Make dists
-      run: python -m build
+        name: >-
+          ${{ needs.pre-setup.outputs.dists-artifact-name }}
+        path: dist/
 
     - name: Login
       run: |
@@ -171,8 +297,8 @@ jobs:
       uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
         inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
+          dist/${{ needs.pre-setup.outputs.sdist-artifact-name }}
+          dist/${{ needs.pre-setup.outputs.wheel-artifact-name }}
 
     - name: Upload artifact signatures to GitHub Release
       # Confusingly, this action also supports updating releases, not

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,17 @@
 [tox]
-
 envlist = check, clean, {py39,py310,py311,py312,py313}, report
+minversion = 4
+
+
+[python-cli-options]
+byte-warnings = -b
+byte-errors = -bb
+max-isolation = -E -s -I
+# some-isolation = -I
+# FIXME: Python 2 shim. Is this equivalent to the above?
+some-isolation = -E -s
+warnings-to-errors = -Werror
+
 
 [testenv]
 
@@ -14,6 +25,44 @@ deps =
 
 commands =
   pytest --cov-append {posargs}
+
+
+[testenv:cleanup-dists]
+description =
+  Wipe the the dist{/} folder
+deps =
+commands_pre =
+commands =
+  {envpython} \
+    {[python-cli-options]byte-errors} \
+    {[python-cli-options]max-isolation} \
+    {[python-cli-options]warnings-to-errors} \
+    -c \
+      'import os, shutil, sys; \
+      dists_dir = "{toxinidir}{/}dist{/}"; \
+      shutil.rmtree(dists_dir, ignore_errors=True); \
+      sys.exit(os.path.exists(dists_dir))'
+commands_post =
+package = skip
+
+
+[testenv:build-dists]
+description =
+  Build dists with {basepython} and put them into the dist{/} folder
+depends =
+  cleanup-dists
+deps =
+  build
+commands =
+  {envpython} \
+    {[python-cli-options]byte-errors} \
+    {[python-cli-options]max-isolation} \
+    {[python-cli-options]warnings-to-errors} \
+    -m build \
+      {posargs:}
+commands_post =
+package = skip
+
 
 [testenv:check]
 basepython = python3.13


### PR DESCRIPTION
This includes referencing `reusable-tox.yml`, integrating a "compute vars" job, plugging the artifact download/install into other jobs and cleaning up rebuilds in arbitrary places in CI.

<!-- Thank you for your contribution! -->

## What do these changes do?

$sbj.

## Are there changes in behavior for the user?

Nah.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
