### PR TITLE
Add 2 new Type Hinting functions for helping with function or Protocol Styled approaches

### DIFF
--- a/CHANGES/705.feature.rst
+++ b/CHANGES/705.feature.rst
@@ -1,0 +1,2 @@
+Added extra type hint safety by adding 2 new methods for passing parameter data to a signal either by the use of a wrapper function or when using a class method.
+-- by ``@Vizonex``.

--- a/aiosignal/__init__.py
+++ b/aiosignal/__init__.py
@@ -79,7 +79,9 @@ def signal_func(_: _AsyncFunc[_P, None]) -> type[Signal[_P, None]]:
     return Signal
 
 
-def signal_method(_: _AsyncFunc[Concatenate[_Self, _P], None]) -> type[Signal[_P, None]]:
+def signal_method(
+    _: _AsyncFunc[Concatenate[_Self, _P], None]
+) -> type[Signal[_P, None]]:
     """Helper that typehints a class method as a signal
     This could help assist in creating Protocol Types that can
     define the creation of an object

--- a/aiosignal/__init__.py
+++ b/aiosignal/__init__.py
@@ -7,11 +7,7 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import ParamSpec, Concatenate
 
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
-
+_Self = TypeVar("_Self", contravariant=True)
 _P = ParamSpec("_P")
 _T = TypeVar("_T", contravariant=True)
 _AsyncFunc = Callable[_P, Awaitable[_T]]
@@ -83,7 +79,7 @@ def signal_func(_: _AsyncFunc[_P, None]) -> type[Signal[_P, None]]:
     return Signal
 
 
-def signal_method(_: _AsyncFunc[Concatenate[Self, _P], None]) -> type[Signal[_P, None]]:
+def signal_method(_: _AsyncFunc[Concatenate[_Self, _P], None]) -> type[Signal[_P, None]]:
     """Helper that typehints a class method as a signal
     This could help assist in creating Protocol Types that can
     define the creation of an object

--- a/aiosignal/__init__.py
+++ b/aiosignal/__init__.py
@@ -1,6 +1,5 @@
 import sys
-from typing import Awaitable, Callable, TypeVar, Type
-from abc import ABCMeta
+from typing import Awaitable, Callable, TypeVar
 from frozenlist import FrozenList
 
 if sys.version_info >= (3, 10):

--- a/aiosignal/__init__.py
+++ b/aiosignal/__init__.py
@@ -73,7 +73,7 @@ def signal_func(_: _AsyncFunc[_P, None]) -> type[Signal[_P, None]]:
         event = my_signal(None)
 
         # Now we can create helpuful callbacks with
-        # helpful parameters to help us if were stuck...
+        # helpful parameter hints to help us if were stuck...
 
         @event
         async def on_my_event(a:int, b:int):
@@ -101,7 +101,7 @@ def signal_method(_: _AsyncFunc[Concatenate[Self, _P], None]) -> type[Signal[_P,
 
         MySignal: MySignalProtocol[dict, int] = Signal
 
-        # Signal is now been typehinted via protocol
+        # Signal has now been typehinted via protocol
         # pyright or other ides should be able to
         # identify it as:
         #   (owner:object) -> Signal[(a: dict, b: int), None]

--- a/aiosignal/__init__.py
+++ b/aiosignal/__init__.py
@@ -1,20 +1,25 @@
 import sys
-from typing import Awaitable, Callable, TypeVar
-
+from typing import Awaitable, Callable, TypeVar, Type
+from abc import ABCMeta
 from frozenlist import FrozenList
 
 if sys.version_info >= (3, 10):
-    from typing import ParamSpec
+    from typing import ParamSpec, Concatenate
 else:
-    from typing_extensions import ParamSpec
+    from typing_extensions import ParamSpec, Concatenate
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 _P = ParamSpec("_P")
-_T = TypeVar("_T")
+_T = TypeVar("_T", contravariant=True)
 _AsyncFunc = Callable[_P, Awaitable[_T]]
 
 __version__ = "1.3.2"
 
-__all__ = ("Signal",)
+__all__ = ("Signal", "signal_func", "signal_method")
 
 
 class Signal(FrozenList[_AsyncFunc[_P, _T]]):
@@ -51,3 +56,58 @@ class Signal(FrozenList[_AsyncFunc[_P, _T]]):
         """Decorator to add a function to this Signal."""
         self.append(func)
         return func
+
+
+def signal_func(_: _AsyncFunc[_P, None]) -> type[Signal[_P, None]]:
+    """overrides a function to define a function as a 
+    signal that can be defined with typehinted parameters::
+
+        from aiosignal import signal_func
+
+        @signal_func
+        async def my_signal(a:int, b:int) -> None:...
+
+        # my_signal has been transformed to a Signal 
+        # and it should now be typehinted as: 
+        # (owner: object) -> Signal[(a: int, b: int), None]
+         
+        event = my_signal(None)
+
+        # Now we can create helpuful callbacks with 
+        # helpful parameters to help us if were stuck...
+
+        @event
+        async def on_my_event(a:int, b:int):
+            ...
+
+    """
+    return Signal
+
+
+def signal_method(_: _AsyncFunc[Concatenate[Self, _P], None]) -> type[Signal[_P, None]]:
+    """Helper that typehints a class method as a signal
+    This could help assist in creating Protocol Types that can 
+    define the creation of an object 
+
+    ::
+
+        from typing import TypeVar, Protocol
+
+        A = TypeVar("A")
+        B = TypeVar("B")
+
+        class MySignalProtocol(Protocol[A, B]):
+            @signal_method
+            def __call__(self, a: A, b: B) -> None:...
+
+        MySignal: MySignalProtocol[dict, int] = Signal
+
+        # Signal is now been typehinted via protocol
+        # pyright or other ides should be able to 
+        # identify it as: 
+        #   (owner:object) -> Signal[(a: dict, b: int), None]
+
+        signal = MySignal()
+
+    """
+    return Signal

--- a/aiosignal/__init__.py
+++ b/aiosignal/__init__.py
@@ -59,7 +59,7 @@ class Signal(FrozenList[_AsyncFunc[_P, _T]]):
 
 
 def signal_func(_: _AsyncFunc[_P, None]) -> type[Signal[_P, None]]:
-    """overrides a function to define a function as a 
+    """overrides a function to define a function as a
     signal that can be defined with typehinted parameters::
 
         from aiosignal import signal_func
@@ -67,13 +67,13 @@ def signal_func(_: _AsyncFunc[_P, None]) -> type[Signal[_P, None]]:
         @signal_func
         async def my_signal(a:int, b:int) -> None:...
 
-        # my_signal has been transformed to a Signal 
-        # and it should now be typehinted as: 
+        # my_signal has been transformed to a Signal
+        # and it should now be typehinted as:
         # (owner: object) -> Signal[(a: int, b: int), None]
-         
+
         event = my_signal(None)
 
-        # Now we can create helpuful callbacks with 
+        # Now we can create helpuful callbacks with
         # helpful parameters to help us if were stuck...
 
         @event
@@ -86,8 +86,8 @@ def signal_func(_: _AsyncFunc[_P, None]) -> type[Signal[_P, None]]:
 
 def signal_method(_: _AsyncFunc[Concatenate[Self, _P], None]) -> type[Signal[_P, None]]:
     """Helper that typehints a class method as a signal
-    This could help assist in creating Protocol Types that can 
-    define the creation of an object 
+    This could help assist in creating Protocol Types that can
+    define the creation of an object
 
     ::
 
@@ -103,8 +103,8 @@ def signal_method(_: _AsyncFunc[Concatenate[Self, _P], None]) -> type[Signal[_P,
         MySignal: MySignalProtocol[dict, int] = Signal
 
         # Signal is now been typehinted via protocol
-        # pyright or other ides should be able to 
-        # identify it as: 
+        # pyright or other ides should be able to
+        # identify it as:
         #   (owner:object) -> Signal[(a: dict, b: int), None]
 
         signal = MySignal()

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ include_package_data = True
 
 install_requires =
   frozenlist >= 1.1.0
-  typing-extensions >= 3.10; python_version <= '3.9'
+  typing-extensions >= 3.10; python_version <= '3.10'
 
 
 [pep8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ include_package_data = True
 
 install_requires =
   frozenlist >= 1.1.0
-  typing-extensions >= 3.10; python_version <= '3.10'
+  typing-extensions >= 3.10; python_version <= '3.9'
 
 
 [pep8]

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,9 +1,11 @@
 import re
 from unittest import mock
+from unittest import mock
+from typing import Protocol, cast
 
 import pytest
 
-from aiosignal import Signal
+from aiosignal import Signal, signal_func, signal_method
 
 
 class Owner:
@@ -169,11 +171,10 @@ async def test_decorator_callback_dispatch_args_kwargs(owner: Owner) -> None:
     await signal.send(*args, **kwargs)
 
 
-
 async def test_paramspec_argument_passing_from_function(owner: Owner):
 
     @signal_func
-    async def defined_signal(foo:int, bar:int):...
+    async def defined_signal(foo: int, bar: int): ...
 
     assert defined_signal == Signal, "Signal did not pass"
 
@@ -192,11 +193,10 @@ async def test_paramspec_argument_passing_from_function(owner: Owner):
 
 
 async def test_paramspec_argument_passing_from_protocol(owner: Owner):
-    # Typehinting should not fail, even if were bound to not
-    # having Self in python 3.11...
+
     class MySignalProtocol(Protocol):
         @signal_method
-        def __call__(self, foo: int, bar: int) -> None:...
+        def __call__(self, foo: int, bar: int) -> None: ...
 
     # Casting Signals from protocol is one of the methods of type-casting
     # What the signal is...

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,6 +1,6 @@
 import re
 from unittest import mock
-from typing import Protocol, cast
+from typing import Awaitable, cast, Protocol
 
 import pytest
 
@@ -195,7 +195,7 @@ async def test_paramspec_argument_passing_from_protocol(owner: Owner):
 
     class MySignalProtocol(Protocol):
         @signal_method
-        def __call__(self, foo: int, bar: int) -> None: ...
+        def __call__(self, foo: int, bar: int) -> Awaitable[None]: ...
 
     # Casting Signals from protocol is one of the methods of type-casting
     # What the signal is...

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,6 +1,5 @@
 import re
 from unittest import mock
-from unittest import mock
 from typing import Protocol, cast
 
 import pytest

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -171,7 +171,7 @@ async def test_decorator_callback_dispatch_args_kwargs(owner: Owner) -> None:
 
 
 async def test_paramspec_argument_passing_from_function(owner: Owner):
-    
+
     @signal_func
     async def defined_signal(foo:int, bar:int):...
 
@@ -188,16 +188,16 @@ async def test_paramspec_argument_passing_from_function(owner: Owner):
         callback_mock(*args, **kwargs)
 
     signal.freeze()
-    await signal.send(*args, **kwargs)    
+    await signal.send(*args, **kwargs)
 
 
 async def test_paramspec_argument_passing_from_protocol(owner: Owner):
-    # Typehinting should not fail, even if were bound to not 
+    # Typehinting should not fail, even if were bound to not
     # having Self in python 3.11...
     class MySignalProtocol(Protocol):
         @signal_method
         def __call__(self, foo: int, bar: int) -> None:...
-    
+
     # Casting Signals from protocol is one of the methods of type-casting
     # What the signal is...
     signal = cast(MySignalProtocol, Signal)(owner)
@@ -212,4 +212,3 @@ async def test_paramspec_argument_passing_from_protocol(owner: Owner):
 
     signal.freeze()
     await signal.send(*args, **kwargs)
-

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,6 +1,6 @@
 import re
 from unittest import mock
-from typing import Awaitable, cast, Protocol
+from typing import Protocol, cast, Awaitable
 
 import pytest
 
@@ -173,7 +173,8 @@ async def test_decorator_callback_dispatch_args_kwargs(owner: Owner) -> None:
 async def test_paramspec_argument_passing_from_function(owner: Owner):
 
     @signal_func
-    async def defined_signal(foo: int, bar: int): ...
+    async def defined_signal(foo: int, bar: int):
+        return
 
     assert defined_signal == Signal, "Signal did not pass"
 
@@ -195,7 +196,8 @@ async def test_paramspec_argument_passing_from_protocol(owner: Owner):
 
     class MySignalProtocol(Protocol):
         @signal_method
-        def __call__(self, foo: int, bar: int) -> Awaitable[None]: ...
+        def __call__(self, foo: int, bar: int) -> Awaitable[None]:
+            return
 
     # Casting Signals from protocol is one of the methods of type-casting
     # What the signal is...

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -167,3 +167,49 @@ async def test_decorator_callback_dispatch_args_kwargs(owner: Owner) -> None:
 
     signal.freeze()
     await signal.send(*args, **kwargs)
+
+
+
+async def test_paramspec_argument_passing_from_function(owner: Owner):
+    
+    @signal_func
+    async def defined_signal(foo:int, bar:int):...
+
+    assert defined_signal == Signal, "Signal did not pass"
+
+    signal = defined_signal(owner)
+    args = {"a", "b"}
+    kwargs = {"foo": 1, "bar": 2}
+
+    callback_mock = mock.Mock()
+
+    @signal
+    async def callback(*args: object, **kwargs: object) -> None:
+        callback_mock(*args, **kwargs)
+
+    signal.freeze()
+    await signal.send(*args, **kwargs)    
+
+
+async def test_paramspec_argument_passing_from_protocol(owner: Owner):
+    # Typehinting should not fail, even if were bound to not 
+    # having Self in python 3.11...
+    class MySignalProtocol(Protocol):
+        @signal_method
+        def __call__(self, foo: int, bar: int) -> None:...
+    
+    # Casting Signals from protocol is one of the methods of type-casting
+    # What the signal is...
+    signal = cast(MySignalProtocol, Signal)(owner)
+    args = {"a", "b"}
+    kwargs = {"foo": 1, "bar": 2}
+
+    callback_mock = mock.Mock()
+
+    @signal
+    async def callback(*args: object, **kwargs: object) -> None:
+        callback_mock(*args, **kwargs)
+
+    signal.freeze()
+    await signal.send(*args, **kwargs)
+


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

My [old pull request](https://github.com/aio-libs/aiohttp/pull/11123) I tried doing the previous day to `aiohttp` just wouldn't cut it, and it felt a little embarrassing to have to close it and start over :/

There should first need to be a way to converse between 2 different Styles of writing functions as well as 2 different ways to send `ParamSpec` type hints through to a `Signal` so that it ides like __pyright__ would know how to carry them. This way type hinting is kept retained and we don't need to create any extreme changes to `TraceConfig` on aiohttp such as overriding as member descriptors (maybe not the best approach here).

Wanted to make sure users could see what kind of parameters were being passed through __pyright__ or __mypy__ no matter what the circumstances were, therefore I had decided to make sure these 2 two function were also heavily documented, know that it's not perfect but it's a start. 

I created 2 different approaches to solve passing `ParamSpec` Keywords.

## Method 1 Passing via Function Signature

```python
from aiosignal import signal_func

@signal_func
async def my_signal(a:int, b:int) -> None:...

# my_signal has been transformed to a Signal 
# and it should now be able to the see the typehints: 
#   (owner: object) -> Signal[(a: int, b: int), None]
s = my_signal(None)

```

## Method 2 Passing via Protocol

Probably the one everyone maintaining aiohttp wanted to see...
I was primarily looking for a way to make the protocol manipulatable and it took me about 2 to 3 
hours of research and attempts to get it right and since we can't use function generics like in __Python 3.12__ 
This was the most creative idea I could come up with. Type hints passed, users can see what to send through 
`TraceConfig` , problem solved. The bonus is that using Generics makes the parameters manipulatable this is something
that aiohttp does with `TraceConfig` on a heavy scale. Type casting should also work as intended as well.

```python
        from typing import TypeVar, Protocol

        A = TypeVar("A")
        B = TypeVar("B")

        class MySignalProtocol(Protocol[A, B]):
            @signal_method
            def __call__(self, a: A, b: B) -> None:...

        MySignal: MySignalProtocol[dict, int] = Signal

        # Signal is now been typehinted via protocol
        # pyright or other ides should be able to 
        # identify it as: 
        #   (owner:object) -> Signal[(a: dict, b: int), None]

        signal = MySignal()
```

## Are there changes in behavior for the user?

There shouldn't be all I added were 2 new functions to ensure that users had a way to pass `ParamSpec` arguments to the Signal class that I had established as a result of reviving this library. This was the puzzle that needed solving. Having the full signature rather than a `Callable` would help users to see & identify different keyword arguments and types if any are to be passed.

## Related issue number

- Resolves my embarrassing attempts at making `TraceConfig` better (https://github.com/aio-libs/aiohttp/pull/11123) .

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
