### PR TITLE
Use callable for typing, rather than ParamSpec

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,14 +9,6 @@ _site-packages-to-src-mapping =
   */lib/python*/site-packages
   *\Lib\site-packages
 
-[report]
-fail_under = 98
-skip_covered = true
-skip_empty = true
-show_missing = true
-exclude_also =
-  ^\s*@pytest\.mark\.xfail
-
 [run]
 branch = true
 cover_pylib = false

--- a/CHANGES/699.feature.rst
+++ b/CHANGES/699.feature.rst
@@ -1,4 +1,2 @@
-Improved type safety by allowing callback parameters to be type checked (``typing-extensions`` is now required for Python 3.9).
-
 Added decorator functionality to ``Signal`` as a convenient way to add a callback
 -- by ``@Vizonex``.

--- a/CHANGES/710.feature.rst
+++ b/CHANGES/710.feature.rst
@@ -1,0 +1,2 @@
+Improved type safety by allowing callback parameters to be type checked (``typing-extensions`` is now required for Python <3.13).
+-- by ``@Vizonex`` and ``@Dreamsorcerer``.

--- a/aiosignal/__init__.py
+++ b/aiosignal/__init__.py
@@ -3,11 +3,6 @@ from typing import Any, Awaitable, Callable, TypeVar
 
 from frozenlist import FrozenList
 
-if sys.version_info >= (3, 10):
-    from typing import ParamSpec
-else:
-    from typing_extensions import ParamSpec
-
 if sys.version_info >= (3, 11):
     from typing import Unpack
 else:
@@ -56,7 +51,9 @@ class Signal(FrozenList[Callable[[Unpack[_Ts]], Awaitable[object]]]):
         for receiver in self:
             await receiver(*args, **kwargs)
 
-    def __call__(self, func: Callable[[Unpack[_Ts]], Awaitable[_T]]) -> Callable[[Unpack[_Ts]], Awaitable[_T]]:
+    def __call__(
+        self, func: Callable[[Unpack[_Ts]], Awaitable[_T]]
+    ) -> Callable[[Unpack[_Ts]], Awaitable[_T]]:
         """Decorator to add a function to this Signal."""
         self.append(func)
         return func

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,14 @@ and dropping callbacks is forbidden.
 The only available operation is calling the previously registered
 callbacks by using ``await sig.send(data)``.
 
+The callback parameters, which should be passed in the ``.send()`` call, can be
+specificied for a type checker:
+
+```python
+signal = Signal[int, str](owner)
+signal.send(42, "foo")
+```
+
 For concrete usage examples see the :ref:`aiohttp:aiohttp-web-signals` section of the :doc:`aiohttp:web_advanced` chapter of the :doc:`aiohttp documentation <aiohttp:index>`.
 
 API

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ The only available operation is calling the previously registered
 callbacks by using ``await sig.send(data)``.
 
 The callback parameters, which should be passed in the ``.send()`` call, can be
-specificied for a type checker:
+specified for a type checker:
 
 ```python
 signal = Signal[int, str](owner)

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ include_package_data = True
 
 install_requires =
   frozenlist >= 1.1.0
-  typing-extensions >= 4.2; python_version <= '3.13'
+  typing-extensions >= 4.2; python_version < '3.13'
 
 
 [pep8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ include_package_data = True
 
 install_requires =
   frozenlist >= 1.1.0
-  typing-extensions >= 3.10; python_version <= '3.9'
+  typing-extensions >= 4.2; python_version <= '3.11'
 
 
 [pep8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ include_package_data = True
 
 install_requires =
   frozenlist >= 1.1.0
-  typing-extensions >= 4.2; python_version <= '3.11'
+  typing-extensions >= 4.2; python_version <= '3.13'
 
 
 [pep8]


### PR DESCRIPTION
This is easier to annotate Signal compared to ParamSpec. This focuses on simple callbacks with positional parameters. We could consider expanding this with a separate version for ParamSpec in the future if there's demand, but this is probably enough for now.

Types can be annotated like `Signal[int, str]`.

## Checklist

- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder