### PR TITLE
Add Test for TypeVarTuple

### DIFF
--- a/CHANGES/710.feature.rst
+++ b/CHANGES/710.feature.rst
@@ -1,0 +1,1 @@
+made ``Signal`` positional arguments easier to annotate -- by ``@Dreamsorcerer``.

--- a/CHANGES/711.feature.rst
+++ b/CHANGES/711.feature.rst
@@ -1,0 +1,1 @@
+Added ``TypeVarTuple`` test for aiosignal -- by ``@Vizonex``.

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -19,7 +19,7 @@ def owner() -> Owner:
 async def test_add_signal_handler_not_a_callable(owner: Owner) -> None:
     callback = True
     signal = Signal(owner)
-    signal.append(callback) # type: ignore
+    signal.append(callback)  # type: ignore
     signal.freeze()
     with pytest.raises(TypeError):
         await signal.send()
@@ -169,13 +169,15 @@ async def test_decorator_callback_dispatch_args_kwargs(owner: Owner) -> None:
     await signal.send(*args, **kwargs)
 
 async def test_type_var_protocol(owner: Owner) -> None:
+
     signal: Signal[str, str, int, int] = Signal(owner)
+
     callback_mock = mock.Mock()
 
-    @signal
-    async def callback(a:str, b:str, foo:int, bar:int):
+    @signal()
+    async def callback(a: str, b: str, foo: int, bar: int):
         assert a == "a" and b == "b" and foo == 1 and bar == 2
         callback_mock(a, b, foo, bar)
 
     signal.freeze()
-    await signal.send("a", "b", 1, 2)
+    await signal.send("a", "b", 1, 2)  # type: ignore

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -19,7 +19,7 @@ def owner() -> Owner:
 async def test_add_signal_handler_not_a_callable(owner: Owner) -> None:
     callback = True
     signal = Signal(owner)
-    signal.append(callback)
+    signal.append(callback) # type: ignore
     signal.freeze()
     with pytest.raises(TypeError):
         await signal.send()
@@ -167,3 +167,17 @@ async def test_decorator_callback_dispatch_args_kwargs(owner: Owner) -> None:
 
     signal.freeze()
     await signal.send(*args, **kwargs)
+
+async def test_type_var_protocol(owner: Owner) -> None:
+    signal: Signal[str, str, int, int] = Signal(owner)
+    callback_mock = mock.Mock()
+    
+    @signal
+    async def callback(a:str, b:str, foo:int, bar:int):
+        assert a == "a" and b == "b" and foo == 1 and bar == 2
+        callback_mock(a, b, foo, bar)
+
+    signal.freeze()
+    await signal.send("a", "b", 1, 2)
+
+

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -171,7 +171,7 @@ async def test_decorator_callback_dispatch_args_kwargs(owner: Owner) -> None:
 async def test_type_var_protocol(owner: Owner) -> None:
     signal: Signal[str, str, int, int] = Signal(owner)
     callback_mock = mock.Mock()
-    
+
     @signal
     async def callback(a:str, b:str, foo:int, bar:int):
         assert a == "a" and b == "b" and foo == 1 and bar == 2
@@ -179,5 +179,3 @@ async def test_type_var_protocol(owner: Owner) -> None:
 
     signal.freeze()
     await signal.send("a", "b", 1, 2)
-
-


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Added a test for the new `TypeVarTuple` so that we can ensure it works correctly.

## Are there changes in behavior for the user?

Only thing is that `TypeVarTuple` is going to put an end to some hinting problems VSCode and other Coding software may have trouble with solving. Adding in this additional test for it ensures that things are going to work as intended.

## Related issue number

- #710

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
