### PR TITLE
Fix broken RST links in README and update outdated docs

### DIFF
--- a/CHANGES/794.doc
+++ b/CHANGES/794.doc
@@ -1,0 +1,1 @@
+Fixed broken RST hyperlinks in README, added missing ``await`` in docs code example, and updated outdated Python and frozenlist version requirements in documentation to match ``setup.cfg``.

--- a/README.rst
+++ b/README.rst
@@ -44,9 +44,9 @@ The only available operation is calling the previously registered
 callbacks by using ``await sig.send(data)``.
 
 For concrete usage examples see the `Signals
-<https://docs.aiohttp.org/en/stable/web_advanced.html#aiohttp-web-signals>
+<https://docs.aiohttp.org/en/stable/web_advanced.html#aiohttp-web-signals>`_
 section of the `Web Server Advanced
-<https://docs.aiohttp.org/en/stable/web_advanced.html>` chapter of the `aiohttp
+<https://docs.aiohttp.org/en/stable/web_advanced.html>`_ chapter of the `aiohttp
 documentation`_.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ The callback parameters, which should be passed in the ``.send()`` call, can be
 specified for a type checker::
 
     signal = Signal[int, str](owner)
-    signal.send(42, "foo")
+    await signal.send(42, "foo")
 
 
 For concrete usage examples see the :ref:`aiohttp:aiohttp-web-signals` section of the :doc:`aiohttp:web_advanced` chapter of the :doc:`aiohttp documentation <aiohttp:index>`.
@@ -54,7 +54,7 @@ Installation
 
    $ pip install aiosignal
 
-The library requires Python 3.8 or newer.
+The library requires Python 3.9 or newer.
 
 Dependencies
 ------------
@@ -78,8 +78,8 @@ Feel free to post your questions and ideas here.
 Requirements
 ============
 
-- Python >= 3.8
-- frozenlist >= 1.0.0
+- Python >= 3.9
+- frozenlist >= 1.1.0
 
 License
 =======


### PR DESCRIPTION
## What do these changes do?

Fix several documentation issues across README.rst and docs/index.rst:

1. **README.rst**: Fix two malformed RST hyperlinks for "Signals" and "Web Server Advanced" -- both were missing the closing `` >`_ `` syntax, causing them to render as broken text on PyPI and GitHub instead of proper clickable links.

2. **docs/index.rst**: Add missing `await` keyword in the type-checker code example. `Signal.send()` is an async method (the docs even mark it with `:async:`), but the example showed `signal.send(42, "foo")` instead of `await signal.send(42, "foo")`.

3. **docs/index.rst**: Update Python version requirement from 3.8 to 3.9 in two places. Python 3.8 support was dropped in v1.3.2, and `setup.cfg` already specifies `python_requires = >=3.9`.

4. **docs/index.rst**: Update frozenlist dependency version from `>= 1.0.0` to `>= 1.1.0` to match what `setup.cfg` actually declares.

## Are there changes in behavior for the user?

No behavior changes. Documentation-only fixes.

## Related issue number

None -- found by code inspection.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder